### PR TITLE
Fixes memory issue when loading data

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.7.2-otp-21
+erlang 21.0.8

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -162,7 +162,7 @@ if Code.ensure_loaded?(Ecto) do
     @type batch_fun :: (Ecto.Queryable.t(), Ecto.Query.t(), [any], Keyword.t() -> [any])
     @type opt ::
             {:query, query_fun}
-            | {:default_params, Map.t}
+            | {:default_params, Map.t()}
             | {:repo_opts, Keyword.t()}
             | {:timeout, pos_integer}
             | {:run_batch, batch_fun()}
@@ -400,15 +400,15 @@ if Code.ensure_loaded?(Ecto) do
         {key, default_params}
       end
 
-      def run_batches(task_supervisor, source) do
+      def run_batches(source) do
         options = [
           timeout: source.options[:timeout] || Dataloader.default_timeout(),
           on_timeout: :kill_task
         ]
 
         results =
-          task_supervisor
-          |> Task.Supervisor.async_stream(source.batches, &run_batch(&1, source), options)
+          source.batches
+          |> Task.async_stream(&run_batch(&1, source), options)
           |> Enum.map(fn
             {:ok, {_key, result}} -> {:ok, result}
             {:exit, reason} -> {:error, reason}


### PR DESCRIPTION
Currently the supervisor that gets spawned to supervise tasks doesn't
get killed when the work has completed, leading to the memory to grow
continuously when querying for large amounts of data.

This removes the need for the supervisor at all, eliminating the
problem.